### PR TITLE
Handle article body in imageurl

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,10 +1,16 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Table
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 
 from datetime import datetime
 
 Base = declarative_base()
+
+article_category = Table(
+    'article_category', Base.metadata,
+    Column('article_id', Integer, ForeignKey('article.id'), primary_key=True),
+    Column('category_id', Integer, ForeignKey('category.id'), primary_key=True)
+)
 
 class Site(Base):
     __tablename__ = "site"
@@ -28,13 +34,12 @@ class Category(Base):
     updated_at = Column(DateTime, nullable=True, comment="수정일")
     
     site = relationship("Site", back_populates="categories")
-    articles = relationship("Article", back_populates="category")
+    articles = relationship("Article", secondary=article_category, back_populates="categories")
 
 class Article(Base):
     __tablename__ = "article"
     
     id = Column(Integer, primary_key=True, index=True, autoincrement=True, comment="id")
-    category_id = Column(Integer, ForeignKey("category.id"), nullable=True, comment="카테고리 id")
     url = Column(String(255), nullable=False, comment="기사 url")
     redirected_url = Column(String(255), nullable=False, comment="기사 redirect url")
     origin_url = Column(String(255), nullable=True, comment="기사 원본 url")
@@ -47,7 +52,7 @@ class Article(Base):
     article_updated_at = Column(String(255), nullable=True, comment="기사 수정일")
     collected_at = Column(DateTime, default=datetime.utcnow, comment="데이터 수집일")
     
-    category = relationship("Category", back_populates="articles")
+    categories = relationship("Category", secondary=article_category, back_populates="articles")
 
     # def __str__(s):
     #     return "id: " + s.id + ", category_id: " + str(s.category_id) + ", url: " + s.url + ", origin_url: " + s.origin_url + ", headline: " + s.headline + ", body: " + s.body + ", img_url: " + s.img_url + ", summary: " + s.summary + ", author: " + s.author + ", article_created_at: " + s.article_created_at + ", article_updated_at: " + s.article_updated_at

--- a/app/scraper.py
+++ b/app/scraper.py
@@ -138,7 +138,7 @@ def update_article_content(article: Article, db, division='plain'):
 
     print("--------------")
     print("id : " + str(article.id))
-    print("category_id : " + str(article.category_id))
+    print("category_id : " + str(article.categories))
     print("url : " + str(article_url))
     print("--------------")
 
@@ -162,8 +162,21 @@ def update_article_content(article: Article, db, division='plain'):
                 dic_area_tag = soup.find('article', {'id':'dic_area'})
                 if dic_area_tag is not None:
                     print('==========body==========')
-                    print(dic_area_tag.text)
-                    article.body = dic_area_tag.text
+                    content = []
+                    for element in dic_area_tag.descendants:
+                        if element.name == 'img':
+                            img_src = element.get('data-src', '')
+                            if img_src:  # data-src가 존재하는 경우에만 커스텀 태그로 감싸기
+                                custom_tagged_img = f'<catch-weak-img>{img_src}</catch-weak-img>'
+                                content.append(custom_tagged_img)
+                        elif element.name not in ['script', 'style'] and element.string and element.parent.name != 'em':
+                            text = element.string.strip() # 스크립트와 스타일 태그를 제외하고, em 태그의 부모가 아닌 경우만 텍스트를 추가
+                            if text:
+                                content.append(text)
+
+                    article_body = '\n'.join(content)
+                    print(article_body)
+                    article.body = article_body
 
                     # summary
                     media_end_summary_tag_list = dic_area_tag.findAll('strong')

--- a/app/scraper.py
+++ b/app/scraper.py
@@ -166,8 +166,9 @@ def update_article_content(article: Article, db, division='plain'):
                     for element in dic_area_tag.descendants:
                         if element.name == 'img':
                             img_src = element.get('data-src', '')
+                            img_alt = element.get('alt', '')
                             if img_src:  # data-src가 존재하는 경우에만 커스텀 태그로 감싸기
-                                custom_tagged_img = f'<catch-weak-img>{img_src}</catch-weak-img>'
+                                custom_tagged_img = f'<catch-weak-img>{img_src} : {img_alt}</catch-weak-img>'
                                 content.append(custom_tagged_img)
                         elif element.name not in ['script', 'style'] and element.string and element.parent.name != 'em':
                             text = element.string.strip() # 스크립트와 스타일 태그를 제외하고, em 태그의 부모가 아닌 경우만 텍스트를 추가


### PR DESCRIPTION
1.  aritcle에 다중 category가질 수 있게 모델링 변경으로 인한 대응
2. 이미지가 포함되어 있는 기사들은 `<catch-weak-img>` 로 image url을 감싸서 기사 본문을 저장하게 변경
3. 예시(`article.id = 82911`를 사용)

  - 이미지 태그 url 예시
```html
<catch-weak-img>https://imgnews.pstatic.net/image/025/2024/06/11/0003366150_002_20240611174108724.jpg?type=w647</catch-weak-img>
```
- 데이터 예시
![image](https://github.com/user-attachments/assets/68a834b1-d3dc-4f17-95ea-e8eb9fb99a1f)

